### PR TITLE
Switch to `ls -lathr` for clearer chronological listing

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -117,7 +117,7 @@ source $ZSH/oh-my-zsh.sh
 # --------------------------------------------------------------------
 
 alias ..='cd ..'
-alias ll='ls -alFh'
+alias ll='ls -lathr'
 alias la='ls -A'
 alias l='ls -CF'
 alias gitv='git log --graph --format="%C(auto)%h%d %s %C(black)%C(bold)%cr"'


### PR DESCRIPTION
Using `ls -lathr` makes it much easier to quickly identify the oldest files in a directory. It's especially helpful when dealing with directories containing numerous files, as the human-readable format and chronological sorting reduce the cognitive overhead when analyzing file details.